### PR TITLE
Pathedit

### DIFF
--- a/src/editor/EditorUtils.java
+++ b/src/editor/EditorUtils.java
@@ -4,6 +4,7 @@ import IO.IOManager;
 import connectableinterface.Connectable;
 import enums.ConnectableTile;
 import enums.EditableTile;
+import enums.Graphics;
 import event.LevelEvent;
 import event.editor.SavePathEvent;
 import gamemanager.GameManager;
@@ -11,6 +12,8 @@ import levelloader.LevelLoader;
 import levelloader.LevelNotSaved;
 import map.Map;
 import tile.*;
+
+import javax.swing.tree.DefaultMutableTreeNode;
 
 import static enums.EditableTile.*;
 import static enums.EditableTile.WALL;
@@ -82,6 +85,17 @@ public class EditorUtils {
     public static void loadLevel(String path) {
         try {
             GameManager.getInstance().setMap(LevelLoader.loadLevel(path));
+            GameManager.getInstance().getEditor().setTreeModel(new editor.TreeModel());
+            for (int i = 0 ; i < GameManager.getInstance().getMap().getWidth() ; ++i)
+            {
+                for (int j = 0 ; j < GameManager.getInstance().getMap().getWidth() ; ++j)
+                {
+                    if (GameManager.getInstance().getMap().getUpperLayer(i,j) instanceof SmartEnemy)
+                    {
+                        GameManager.getInstance().getEditor().getTreeModel().addNode("Smart enemy ("+i+", "+j+")");
+                    }
+                }
+            }
             IOManager.getInstance().drawGame();
             IOManager.getInstance().drawEditor();
         }


### PR DESCRIPTION
+Add pathedit tab with tree and functionality
+`EditorGraphics` as interface instead of working on `EditableTile` and `Arrow` [Arrows for path enum].
+`Editor` now holds current enemy with path, tree structure and **currentPath** - mask for `EditorMapDisplay`.
+`EditorMapDisplay` upgrade.
--------------Change log---------------------
1. All editor logic related classes which used `EditableTile` now use `EditorGraphics` interface
2. `JTree` is only in `PathEditPalette` it's logic and data structure is in `Editor` [Look up `TreeModel`].
3. `Editor` knows which enemy path to display with new editor modes, events and `TreeSelectionListener`.
4. New events for enemy choosing and saving its path. Events are modified to hold `EditorGraphics` instead of `EditableTile`
5. `TilePalette` can now safely be contained in other palettes
6. `EditorMapDisplay` now can display paths and Interactive tiles account for editor modes.
7. You can also select path by clicking enemy on a map when in `PathEditPalette`.

To be implemented:
-Exiting to `PREPATHEDIT` mode from `PRESELECT` mode - to easy switch between enemies
-When enemy is selected on `PREPATHEDIT` selects it on the tree

@Tysek64 
Courtesy of Tysek who helped with JSplitPane and enemy selection when clicked on map.